### PR TITLE
Fix optional cast in CSEDataManager

### DIFF
--- a/CSEDataManager.swift
+++ b/CSEDataManager.swift
@@ -92,8 +92,8 @@ class CSEDataManager {
         if let disablePercentEncoding = data["disablePercentEncoding"] as? Bool {
             parsedData.disablePercentEncoding = disablePercentEncoding
         }
-        if let maxQueryLength = data["maxQueryLength"] as? Int? {
-            if maxQueryLength == nil || maxQueryLength ?? -1 < 0 {
+        if let maxQueryLength = data["maxQueryLength"] as? Int {
+            if maxQueryLength < 0 {
                 parsedData.maxQueryLength = nil
             } else {
                 parsedData.maxQueryLength = maxQueryLength


### PR DESCRIPTION
## Summary
- correct handling of `maxQueryLength` when parsing stored CSE data

## Testing
- `swiftc -parse CSEDataManager.swift`

------
https://chatgpt.com/codex/tasks/task_e_6872463a3700832a8130327c46721f87